### PR TITLE
No auth access to landing page

### DIFF
--- a/components/MyHeader.vue
+++ b/components/MyHeader.vue
@@ -10,10 +10,8 @@ const btnText = computed(() => {
   return 'Login';
 });
 
-const handleAuth = async () => {
-  if (isAuthenticated.value) {
-    await logout();
-  }
+const handleLogout = async () => {
+  await logout();
   return navigateTo({ name: 'login' });
 }
 </script>
@@ -24,8 +22,15 @@ const handleAuth = async () => {
     <NuxtLink :to="{name: 'index'}">
       <img src="/msgoba_2k2_logo.png" class="h-16 " alt="set logo">
     </NuxtLink>
-    <UiBaseBtn v-if="showButton" :label-text="btnText" button-type="button" class="px-8 py-2 bg-oba-red hover:bg-opacity-75 active:bg-opacity-75 rounded-full border-none"
-      text-style="text-oba-white text-lg font-roboto" @click="handleAuth">
+    <UiLinkAsBtn v-if="showButton && !isAuthenticated" :link-dest="{name: 'login'}" :label-text="btnText" class="px-8 py-2 bg-oba-red hover:bg-opacity-75 active:bg-opacity-75 rounded-full border-none"
+      text-style="text-oba-white text-lg font-roboto">
+      <template #prependIcon>
+        <Icon v-if="isAuthenticated" name="bytesize:sign-out" class="text-oba-white" size="16px" />
+        <Icon v-else name="bytesize:sign-in" class="text-oba-white" size="16px" />
+      </template>
+    </UiLinkAsBtn>
+    <UiBaseBtn v-if="showButton && isAuthenticated" button-type="button" :label-text="btnText" class="px-8 py-2 bg-oba-red hover:bg-opacity-75 active:bg-opacity-75 rounded-full border-none"
+      text-style="text-oba-white text-lg font-roboto" @click="handleLogout">
       <template #prependIcon>
         <Icon v-if="isAuthenticated" name="bytesize:sign-out" class="text-oba-white" size="16px" />
         <Icon v-else name="bytesize:sign-in" class="text-oba-white" size="16px" />

--- a/components/ui/LinkAsBtn.vue
+++ b/components/ui/LinkAsBtn.vue
@@ -14,7 +14,13 @@ const props = withDefaults(defineProps<LinkProps>(), {
 
 
 <template>
-  <NuxtLink :to="linkDest" v-bind="$attrs" class="flex flex-row items-center justify-center">
+  <NuxtLink :to="linkDest" v-bind="$attrs" class="flex flex-row items-center justify-center relative">
+    <div class="absolute inset-y-2 left-3">
+      <slot name="prependIcon"></slot>
+    </div>
     <span :class="textStyle">{{ labelText }}</span>
+    <div class="absolute inset-y-2 right-3">
+      <slot name="appendIcon"></slot>
+    </div>
   </NuxtLink>
 </template>

--- a/middleware/musntBeAuthenticated.ts
+++ b/middleware/musntBeAuthenticated.ts
@@ -1,0 +1,8 @@
+export default defineNuxtRouteMiddleware((to, from) => {
+  const { isAuthenticated } = storeToRefs(useAuthStore());
+  const { user } = storeToRefs(useUserStore());
+
+  if (isAuthenticated.value && user.value) {
+    return navigateTo({ name: 'user-userId', params: {userId: user.value.id} });
+  }
+})

--- a/pages/admin/questions/create.vue
+++ b/pages/admin/questions/create.vue
@@ -102,7 +102,11 @@ const submitQuestionCreate = () => {
           </div>
         </FormKit>
         <UiBaseBtn @click="submitQuestionCreate" label-text="Submit" button-type="button" text-style="text-oba-white text-base font-roboto"
-          class="w-full bg-oba-blue rounded-md py-2" :is-disabled="savingQuestion" />
+          class="w-full bg-oba-blue rounded-md py-2" :is-disabled="savingQuestion" >
+          <template #appendIcon>
+            <Icon v-if="savingQuestion" name="line-md:loading-alt-loop" size="16px" class="text-oba-white" />
+          </template>
+        </UiBaseBtn>
       </div>
     </div>
   </section>

--- a/pages/admin/questions/edit/[questionId].vue
+++ b/pages/admin/questions/edit/[questionId].vue
@@ -110,7 +110,11 @@ const submitQuestionEdit = () => {
           </div>
         </FormKit>
         <UiBaseBtn @click="submitQuestionEdit" label-text="Submit" button-type="button" text-style="text-oba-white text-base font-roboto"
-          class="w-full bg-oba-blue rounded-md py-2" :is-disabled="savingQuestion" />
+          class="w-full bg-oba-blue rounded-md py-2" :is-disabled="savingQuestion" >
+          <template #appendIcon>
+            <Icon v-if="savingQuestion" name="line-md:loading-alt-loop" size="16px" class="text-oba-white" />
+          </template>
+        </UiBaseBtn>
       </div>
     </div>
   </section>

--- a/pages/eligibility.vue
+++ b/pages/eligibility.vue
@@ -96,7 +96,11 @@ const handleEligibilityCheck = async (form: Record<string, string>) => {
           </div>
         </FormKit>
         <UiBaseBtn @click="submitEligibilityCheck" label-text="Submit" button-type="button" text-style="text-oba-white text-base font-roboto"
-          class="w-full bg-oba-blue rounded-md py-2" :is-disabled="isChecking" />
+          class="w-full bg-oba-blue rounded-md py-2" :is-disabled="isChecking" >
+          <template #appendIcon>
+            <Icon v-if="isChecking" name="line-md:loading-alt-loop" size="16px" class="text-oba-white" />
+          </template>
+        </UiBaseBtn>
       </div>
     </div>
   </section>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,4 +1,8 @@
 <script lang="ts" setup>
+definePageMeta({
+  middleware: ['musnt-be-authenticated'],
+})
+
 const router = useRouter();
 const goToLogin = () => {
   router.push({ name: 'login' });
@@ -15,7 +19,7 @@ const goToLogin = () => {
     <div class="flex flex-col gap-4 items-center p-8">
       <div class="inline-flex items-center gap-4">
         <span class="text-oba-black font-roboto text-lg">Are you one of us?</span>
-        <UiBaseBtn @click="goToLogin" label-text="Join Us" button-type="button" class="px-8 py-2 bg-oba-blue hover:bg-opacity-75 active:bg-opacity-75 rounded-full border-none"
+        <UiLinkAsBtn :link-dest="{name: 'register'}" label-text="Join Us" class="px-8 py-2 bg-oba-blue hover:bg-opacity-75 active:bg-opacity-75 rounded-full border-none"
           text-style="text-oba-white text-lg font-roboto" />
       </div>
       <div class="inline-flex gap-4">

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -10,10 +10,14 @@ const { user } = storeToRefs(useUserStore());
 const submitLoginForm = () => {
   submitForm('login-form');
 }
+
+const isLoggingIn = ref(false);
 const handleLogin = async (body: { email: string; password: string; }) => {
   const { email, password } = body;
+  isLoggingIn.value = true;
   await emailLogin(email, password);
 
+  isLoggingIn.value = false;
   if (isAuthenticated.value && user.value) {
     const { id } = user.value;
     return navigateTo({ name: 'user-userId', params: { userId: id } });

--- a/pages/register.vue
+++ b/pages/register.vue
@@ -16,7 +16,9 @@ const { isAuthenticated } = storeToRefs(useAuthStore());
 const { user } = storeToRefs(useUserStore());
 const snackbar = useSnackbar();
 
+const isRegistering = ref(false);
 const handleRegister = async (form: UserRegistrationForm) => {
+  isRegistering.value = true;
   await registerUser(form);
   if (user.value) {
     snackbar.add({
@@ -28,6 +30,7 @@ const handleRegister = async (form: UserRegistrationForm) => {
       return navigateTo({ name: 'login' });
     }, 3000);
   }
+  isRegistering.value = false;
 }
 
 </script>
@@ -111,7 +114,11 @@ const handleRegister = async (form: UserRegistrationForm) => {
         </FormKit>
         <div class="my-4 flex flex-col gap-4">
           <UiBaseBtn @click="submitRegisterForm" label-text="Register" button-type="button" text-style="text-oba-white text-base font-roboto"
-            class="w-full bg-oba-blue rounded-md py-2" />
+            class="w-full bg-oba-blue rounded-md py-2" :is-disabled="isRegistering">
+            <template #appendIcon>
+              <Icon v-if="isRegistering" name="line-md:loading-alt-loop" size="16px" class="text-oba-white" />
+            </template>
+          </UiBaseBtn>
 
           <div class="flex flex-col items-center gap-2">
             <span class="text-oba-white text-sm font-roboto font-light">

--- a/stores/questionsStore.ts
+++ b/stores/questionsStore.ts
@@ -1,6 +1,8 @@
 import { defineStore } from "pinia";
 import type { CreateQuestionDto, IQuestion, UpdateQuestionDto, QuestionCreateResponse } from "@/types/question";
 import { fetchKeys } from "../types/enums";
+import { ref } from "vue";
+import { useApiFetch } from "@/composables/useApiFetch";
 
 export const useQuestionsStore = defineStore('questions', () => {
   const questions = ref<IQuestion[]>([]);

--- a/tests/questionStore.spec.ts
+++ b/tests/questionStore.spec.ts
@@ -1,0 +1,80 @@
+import { createPinia, setActivePinia, storeToRefs } from 'pinia';
+import { useQuestionsStore } from '@/stores/questionsStore';
+import * as apiFetch from '@/composables/useApiFetch';
+import type { AsyncDataRequestStatus } from '#app';
+import { ref } from 'vue';
+
+beforeAll(() => {
+  setActivePinia(createPinia());
+});
+
+describe('useQuestionStore', () => {
+    let store: ReturnType<typeof useQuestionsStore>;
+  
+    beforeEach(() => {
+      store = useQuestionsStore();
+    });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates a question store', () => {
+    expect(store).toBeDefined();
+  });
+
+  it('has the correct initial state', () => {
+    expect(store.questions).toEqual([]);
+  });
+
+  it('correctly adds a question', async () => {
+    const dto = {
+      question: 'What is the capital of France?',
+      options: ['Paris', 'London', 'Berlin', 'Madrid'],
+      correct_option: 0,
+    };
+    const returnedData = {
+      data: ref({
+        id: '123abc',
+        question: 'What is the capital of France?',
+        options: ['Paris', 'London', 'Berlin', 'Madrid'],
+      }),
+      error: ref(null),
+      pending: ref(false),
+      refresh: () => Promise.resolve(),
+      clear: () => {},
+      status: ref<AsyncDataRequestStatus>('success'),
+      execute: () => Promise.resolve(),
+    };
+    const mockedFetch = vi.spyOn(apiFetch, 'useApiFetch').mockImplementation(() => Promise.resolve(returnedData));
+
+    await store.addQuestion(dto);
+    expect(store.questions).toEqual([{ id: '123abc', question: 'What is the capital of France?', options: ['Paris', 'London', 'Berlin', 'Madrid'] }]);
+    expect(mockedFetch).toHaveBeenCalledWith('/questions', { method: 'POST', key: 'AddQuestion', body: JSON.stringify(dto) });
+  });
+
+  it('correctly fetches questions', async () => {
+    const returnedData = {
+      data: ref([
+        { id: '123abc', question: 'What is the capital of France?', options: ['Paris', 'London', 'Berlin', 'Madrid'] },
+        { id: '456def', question: 'What is the capital of Germany?', options: ['Paris', 'London', 'Berlin', 'Madrid'] },
+        { id: '456def', question: 'What is the capital of Spain?', options: ['Paris', 'London', 'Berlin', 'Madrid'] },
+      ]),
+      error: ref(null),
+      pending: ref(false),
+      refresh: () => Promise.resolve(),
+      clear: () => { },
+      status: ref<AsyncDataRequestStatus>('success'),
+      execute: () => Promise.resolve(),
+    };
+
+    const mockedFetch = vi.spyOn(apiFetch, 'useApiFetch').mockImplementation(() => Promise.resolve(returnedData));
+
+    await store.fetchQuestions();
+    expect(store.questions).toEqual([
+      { id: '123abc', question: 'What is the capital of France?', options: ['Paris', 'London', 'Berlin', 'Madrid'] },
+      { id: '456def', question: 'What is the capital of Germany?', options: ['Paris', 'London', 'Berlin', 'Madrid'] },
+      { id: '456def', question: 'What is the capital of Spain?', options: ['Paris', 'London', 'Berlin', 'Madrid'] },
+    ]);
+    expect(mockedFetch).toHaveBeenCalledWith('/questions', { method: 'GET', key: 'GetQuestions' });
+  });
+});


### PR DESCRIPTION
- Prevent authenticated users from accessing landing page
- Added loading spinners to form submit buttons in questions crud, as well as register and login forms, and eligibility check form.
- Changed `Login` and `Join Us` buttons on landing page to links.
- Added tests for the questions store.