### PR TITLE
Image Validation

### DIFF
--- a/pages/user/[userId]/profile/create.vue
+++ b/pages/user/[userId]/profile/create.vue
@@ -7,6 +7,7 @@ import type { CreateProfileRawForm } from '@/types/profile';
 import { classLevelOptions, classOptions, classArmOptions } from '@/constants/classes';
 import { fetchKeys } from '@/types/enums';
 import type { IProtoProfile } from '@/types/protoProfile';
+import { acceptedImgFormat, stringToArray } from '@/utils/validators';
 
 const { storeProfile } = useProfileStore();
 const { fetchUser } = useAuthStore();
@@ -104,7 +105,13 @@ const fileSelected = (event: any) => {
                 noFiles: 'hidden'
                 
               }" 
-              :validation="[['required']]"/>
+              :validation="[['required'], ['acceptedImgFormat']]"
+              :validation-rules="{
+                acceptedImgFormat
+              }"
+              :validation-messages="{
+                acceptedImgFormat: 'Image must be a .jpg, .jpeg, or .png file'
+              }"/>
             </div>
             <div class="w-[20%] self-center" v-if="photoPreview">
               <span class="block rounded-full w-12 h-12"

--- a/pages/user/[userId]/profile/edit.vue
+++ b/pages/user/[userId]/profile/edit.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { classOptions, classLevelOptions, classArmOptions } from '@/constants/classes';
 import type { CreateProfileRawForm, IProfileUpdateDto } from '@/types/profile';
-import { stringToArray } from '@/utils/validators';
+import { stringToArray, acceptedImgFormat } from '@/utils/validators';
 
 definePageMeta({
   middleware: ['is-authenticated', 'is-verified', 'is-eligible', 'has-profile'],
@@ -118,7 +118,14 @@ const fileSelected = (event: any) => {
                 fileItem: 'hidden',
                 noFiles: 'hidden'
                 
-              }" />
+              }" 
+              :validation="[['required'], ['acceptedImgFormat']]"
+              :validation-rules="{
+                acceptedImgFormat
+              }"
+              :validation-messages="{
+                acceptedImgFormat: 'Image must be a .jpg, .jpeg, or .png file'
+              }"/>
             </div>
             <div class="w-[20%] self-center" v-if="photoPreview">
               <span class="block rounded-full w-12 h-12"

--- a/pages/user/[userId]/profile/edit.vue
+++ b/pages/user/[userId]/profile/edit.vue
@@ -119,7 +119,7 @@ const fileSelected = (event: any) => {
                 noFiles: 'hidden'
                 
               }" 
-              :validation="[['required'], ['acceptedImgFormat']]"
+              :validation="[['acceptedImgFormat']]"
               :validation-rules="{
                 acceptedImgFormat
               }"

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -11,3 +11,11 @@ export const stringToArray = (node: any, count: number) => {
   const valuesArray = node.value.split(',').map((value: string) => value.trim());
   return valuesArray.filter(Boolean).length >= count;
 }
+
+export const acceptedImgFormat = (node: any) => {
+  const imgFormats = ['jpg', 'jpeg', 'png'];
+  const fileType = node.value[0].file.type;
+  const imgFormat = fileType.split('/')[1];
+
+  return imgFormats.includes(imgFormat);
+}


### PR DESCRIPTION
- Throw a validation error with formkit if image format is not acceptable, in both profile create and edit
- This is necessary to warn users trying to upload images from their iphone galleries that are saved in heic format